### PR TITLE
Typos in the hex sums?

### DIFF
--- a/source/_posts/2018-05-25-Data-Structures-Time-Complexity-for-Beginners-Arrays-HashMaps-Linked-Lists-Stacks-Queues-tutorial.md
+++ b/source/_posts/2018-05-25-Data-Structures-Time-Complexity-for-Beginners-Arrays-HashMaps-Linked-Lists-Stacks-Queues-tutorial.md
@@ -469,8 +469,8 @@ Now let's try again, this time with hex numbers so we can see the offset.
 
 ```js
 // r = 114 or 0x72; a = 97 or 0x61; t = 116 or 0x74
-hash('rat'); // 7,627,122 (r: 114 * 1 + a: 97 * 256 + t: 116 * 65,536) or in hex: 0x726174 (r: 0x72 + a: 0x6100 + t: 0x740000)
-hash('art'); // 7,631,457 or 0x617274
+hash('rat'); // 7,627,122 (r: 114 * 1 + a: 97 * 256 + t: 116 * 65,536) or in hex: 0x746172 (r: 0x72 + a: 0x6100 + t: 0x740000)
+hash('art'); // 7,631,457 or 0x747261
 ```
 
 What about different types?


### PR DESCRIPTION
If I understood it correctly, I think there are 2 typos in the hex sums:
    0x72 + 0x6100 + 0x740000 = 0x746172
    hash('art') = 0x61 + 0x7200 + 0x740000 so i believe the result should be 0x747261